### PR TITLE
Edit gecko.firefox.options

### DIFF
--- a/modules/ROOT/pages/web-testing-in-serenity.adoc
+++ b/modules/ROOT/pages/web-testing-in-serenity.adoc
@@ -319,7 +319,7 @@ You can add more complete JSON configuratio options in the `serenity.conf` file,
 ----
 gecko.firefox.options="""
 {
-    args": ["-headless", "-profile", "/path/to/my/profile"],
+    "args": ["-headless", "-profile", "/path/to/my/profile"],
     "prefs": {
         "dom.ipc.processCount": 8
     },


### PR DESCRIPTION
The config for gecko driver should be:

gecko.firefox.options="""
{
    "args": ["-headless"],
    "prefs": {
        "dom.ipc.processCount": 8
    },
    "log": {
        "level": "trace"
    }
}
"""

(add doublequotation mark before args)