### PR TITLE
Fix chrome.switches configuration

### DIFF
--- a/modules/ROOT/pages/serenity-system-properties.adoc
+++ b/modules/ROOT/pages/serenity-system-properties.adoc
@@ -210,7 +210,7 @@ This is to ensure that web elements are available and usable before they are use
 For alternative behaviour, you can set this value to `DisplayedElementLocatorFactory`, `AjaxElementLocatorFactory` or `DefaultElementLocatorFactory`.
 
 === chrome.switches
-Arguments to be passed to the Chrome driver, separated by commas. Example: `chrome.switches = --incognito;--disable-download-notification`
+Arguments to be passed to the Chrome driver, separated by semicolons. Example: `chrome.switches = --incognito;--disable-download-notification`
 
 // FIXME link to Serenity.useFirefoxProfile()
 === webdriver.firefox.profile


### PR DESCRIPTION
The chrome.switches configuration documentation is incorrect. 

It states that the arguments should be comma separated when they should be semicolon separated.

Closes #65 